### PR TITLE
fix: ensure correct start of orchestrator after redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
-x-netbox:
-  &netbox
+x-netbox: &netbox
   build:
     context: docker/netbox
     dockerfile: Dockerfile
@@ -7,7 +6,7 @@ x-netbox:
     - postgres
     - redis
   env_file: ./docker/netbox/netbox.env
-  user: 'unit:root'
+  user: "unit:root"
   healthcheck:
     start_period: 360s
     timeout: 3s
@@ -26,7 +25,7 @@ services:
   # Shared
   #
   postgres:
-    image: 'postgres:14'
+    image: "postgres:14"
     ports:
       - "5432:5432"
     environment:
@@ -44,7 +43,7 @@ services:
           "--username",
           "nwa",
           "--dbname",
-          "orchestrator-core"
+          "orchestrator-core",
         ]
       interval: "3s"
       timeout: "2s"
@@ -57,6 +56,12 @@ services:
       - sh
       - -c # this is to evaluate the $REDIS_PASSWORD from the env
       - redis-server --requirepass $$REDIS_PASSWORD ## $$ because of docker-compose
+    healthcheck:
+      test: '[ $$(redis-cli --pass "$${REDIS_PASSWORD}" ping) = ''PONG'' ]'
+      start_period: 5s
+      timeout: 3s
+      interval: 1s
+      retries: 5
     env_file: ./docker/redis/redis.env
     volumes:
       - netbox-redis-cache-data:/data
@@ -100,10 +105,7 @@ services:
     ports:
       - "8000:8080"
     entrypoint:
-      [
-        "/opt/netbox/docker-entrypoint.sh",
-        "/etc/netbox/entrypoint.sh"
-      ]
+      ["/opt/netbox/docker-entrypoint.sh", "/etc/netbox/entrypoint.sh"]
 
   netbox-worker:
     <<: *netbox
@@ -145,8 +147,7 @@ services:
       orchestrator:
         condition: service_started
 
-  orchestrator:
-    &orchestrator
+  orchestrator: &orchestrator
     image: "ghcr.io/workfloworchestrator/orchestrator-core:latest"
     env_file: ./docker/orchestrator/orchestrator.env
     environment:
@@ -170,9 +171,11 @@ services:
       - ./alembic.ini:/home/orchestrator/alembic.ini
       - ./translations:/home/orchestrator/translations
       - ./templates:/home/orchestrator/templates
-    entrypoint: [ "/home/orchestrator/etc/orchestrator/entrypoint.sh" ]
+    entrypoint: ["/home/orchestrator/etc/orchestrator/entrypoint.sh"]
     depends_on:
       postgres:
+        condition: service_healthy
+      redis:
         condition: service_healthy
 
   #


### PR DESCRIPTION
You should also add curl to the orchestrator image and add a proper healthcheck, and then change `depends_on` for ochestrator condition in `rover-compose` service.

Like this:

```yaml
  rover-compose:
    build:
      context: docker/federation
      dockerfile: rover.Dockerfile
    depends_on:
      orchestrator:
        condition: service_healthy
      netbox:
        condition: service_healthy
    environment:
      - APOLLO_ELV2_LICENSE=accept
      - APOLLO_TELEMETRY_DISABLED=true
    command: supergraph compose --config /app/supergraph-config.yaml --output /app/supergraph.graphql --skip-update-check
    volumes:
      - ./docker/federation:/app

  orchestrator: &orchestrator
    image: "ghcr.io/workfloworchestrator/orchestrator-core:latest"
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:8080/api/graphql"]
      interval: 10s
      timeout: 5s
      retries: 5
......
```