### PR TITLE
updating variables to point at new container names

### DIFF
--- a/docker/orchestrator/orchestrator.env
+++ b/docker/orchestrator/orchestrator.env
@@ -6,8 +6,8 @@ WEBSOCKET_BROADCASTER_URL="redis://:nwa@redis:6379"
 NETBOX_TOKEN=e744057d755255a31818bf74df2350c26eeabe54
 NETBOX_URL=http://netbox:8080/
 OAUTH2_ACTIVE=False
-LSO_PLAYBOOK_URL=http://example-orchestrator-lso-1:8000/api/playbook
-ORCHESTRATOR_URL=http://example-orchestrator-orchestrator-1:8080
+LSO_PLAYBOOK_URL=http://orchestrator-lso:8000/api/playbook
+ORCHESTRATOR_URL=http://orchestrator:8080
 FEDERATION_ENABLED=True
 CACHE_URI=redis://:nwa@redis:6379/0
 


### PR DESCRIPTION
The purpose of this PR is to fix an issue that was created by https://github.com/workfloworchestrator/example-orchestrator/commit/c8039535f2dc2ab841dcd0872a54c9ac2a1e59a4

Specifically, the updating of the `container_name` values in the compose file has meant that the variables for `LSO_PLAYBOOK_URL` and `ORCHESTRATOR_URL` are pointing to invalid services and are therefore breaking LSO connectivity as well as backend connectivity from the UI.