### PR TITLE
Pin redis/nginx to a working version, migrate pydantic-forms imports

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -6,8 +6,7 @@ file_template = %%(year)d-%%(month).2d-%%(day).2d_%%(rev)s_%%(slug)s
 
 # set to 'true' to run the environment during
 # the 'revision' command, regardless of autogenerate
-# revision_environment = false
-script_location = migrations
+script_location = %(here)s/migrations
 version_locations = %(here)s/migrations/versions/schema
 # Logging configuration
 [loggers]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
 
   redis:
     container_name: redis
-    image: docker.io/redis:7-alpine
+    image: docker.io/redis:7.4.2-alpine
     command:
       - sh
       - -c # this is to evaluate the $REDIS_PASSWORD from the env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -218,7 +218,7 @@ services:
 
   nginx:
     container_name: nginx
-    image: "nginx:1.27-alpine"
+    image: "nginx:1.27.3-alpine"
     ports:
       - "80:80"
     volumes:

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,17 +1,16 @@
-import logging
-
+import structlog
 from alembic import context
+from sqlalchemy import engine_from_config, pool
+
 from orchestrator.db.database import BaseModel
 from orchestrator.settings import app_settings
-from sqlalchemy import engine_from_config, pool
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
 
-# Interpret the config file for Python logging.
-# This line sets up loggers basically.
-logger = logging.getLogger("alembic.env")
+# Setup logging
+logger = structlog.get_logger()
 
 config.set_main_option("sqlalchemy.url", str(app_settings.DATABASE_URI))
 

--- a/products/product_blocks/port.py
+++ b/products/product_blocks/port.py
@@ -12,10 +12,11 @@
 # limitations under the License.
 
 
+from pydantic_forms.types import strEnum
 from typing import List
 
 from orchestrator.domain.base import ProductBlockModel
-from orchestrator.types import SubscriptionLifecycle, strEnum
+from orchestrator.types import SubscriptionLifecycle
 from pydantic import computed_field
 
 from products.product_blocks.node import NodeBlock, NodeBlockInactive, NodeBlockProvisioning

--- a/products/product_types/node.py
+++ b/products/product_types/node.py
@@ -12,8 +12,9 @@
 # limitations under the License.
 
 
+from pydantic_forms.types import strEnum
 from orchestrator.domain.base import SubscriptionModel
-from orchestrator.types import SubscriptionLifecycle, strEnum
+from orchestrator.types import SubscriptionLifecycle
 
 from products.product_blocks.node import NodeBlock, NodeBlockInactive, NodeBlockProvisioning
 

--- a/services/lso_client.py
+++ b/services/lso_client.py
@@ -15,6 +15,7 @@
 :term:`LSO` is responsible for executing Ansible playbooks, that deploy subscriptions.
 """
 
+from pydantic_forms.types import State
 import json
 import logging
 from os import getenv
@@ -23,7 +24,6 @@ from typing import Any
 import requests
 from orchestrator import step
 from orchestrator.config.assignee import Assignee
-from orchestrator.types import State
 from orchestrator.utils.errors import ProcessFailureError
 from orchestrator.workflow import conditional, Step, StepList, begin, callback_step, inputstep
 from pydantic_forms.core import FormPage

--- a/services/netbox.py
+++ b/services/netbox.py
@@ -278,6 +278,7 @@ def skip_network_address(ip_prefix: Prefixes) -> None:
     Helper function for reserve_loopback_addresses().
     Ensures that the first available ip from the prefix is not a network address.
     """
+
     def is_network_address(address: IpAddresses) -> bool:
         addr = IPv4Interface(address) if address.family == 4 else IPv6Interface(address)
         return addr.ip == addr.network.network_address
@@ -290,8 +291,6 @@ def skip_network_address(ip_prefix: Prefixes) -> None:
             return
 
         ip_prefix.available_ips.create({"description": "placeholder"})
-
-
 
 
 def reserve_loopback_addresses(device_id: int) -> Tuple:

--- a/workflows/core_link/create_core_link.py
+++ b/workflows/core_link/create_core_link.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 
+from pydantic_forms.types import UUIDstr
 import uuid
 import json
 from random import randrange
@@ -19,7 +20,7 @@ from typing import TypeAlias, cast
 
 from orchestrator.services.products import get_product_by_id
 from orchestrator.targets import Target
-from orchestrator.types import SubscriptionLifecycle, UUIDstr
+from orchestrator.types import SubscriptionLifecycle
 from orchestrator.workflow import StepList, begin, step
 from orchestrator.workflows.steps import store_process_subscription
 from orchestrator.workflows.utils import create_workflow
@@ -191,6 +192,7 @@ def provision_core_link_in_nrm(subscription: CoreLinkProvisioning) -> State:
     subscription.core_link.nrm_id = randrange(2**16)
     return {"subscription": subscription}
 
+
 @step("Install core-link config")
 def provision_core_link(
     subscription: CoreLinkProvisioning,
@@ -211,6 +213,7 @@ def provision_core_link(
     )
 
     return {"subscription": subscription}
+
 
 @create_workflow("Create core_link", initial_input_form=initial_input_form_generator)
 def create_core_link() -> StepList:

--- a/workflows/core_link/modify_core_link.py
+++ b/workflows/core_link/modify_core_link.py
@@ -12,7 +12,8 @@
 # limitations under the License.
 
 
-from orchestrator.types import SubscriptionLifecycle, UUIDstr
+from pydantic_forms.types import UUIDstr
+from orchestrator.types import SubscriptionLifecycle
 from orchestrator.workflow import StepList, begin, step
 from orchestrator.workflows.steps import set_status
 from orchestrator.workflows.utils import modify_workflow

--- a/workflows/core_link/terminate_core_link.py
+++ b/workflows/core_link/terminate_core_link.py
@@ -11,8 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pydantic_forms.types import UUIDstr
+from pydantic_forms.types import InputForm
 import json
-from orchestrator.types import InputForm, UUIDstr
 from orchestrator.workflow import StepList, begin, step
 from orchestrator.workflows.utils import terminate_workflow
 from pydantic_forms.core import FormPage
@@ -68,6 +69,7 @@ def disable_ports(subscription: CoreLink) -> State:
 
     return {"subscription": subscription, "payload_port_a": payload_port_a, "payload_port_b": payload_port_b}
 
+
 @step("Remove core-link config")
 def deprovision_core_link(
     subscription: CoreLink,
@@ -88,6 +90,7 @@ def deprovision_core_link(
     )
 
     return {"subscription": subscription}
+
 
 @terminate_workflow("Terminate core_link", initial_input_form=terminate_initial_input_form_generator)
 def terminate_core_link() -> StepList:

--- a/workflows/core_link/validate_core_link.py
+++ b/workflows/core_link/validate_core_link.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 
-from orchestrator.types import State
+from pydantic_forms.types import State
 from orchestrator.workflow import StepList, begin, step
 from orchestrator.workflows.utils import validate_workflow
 

--- a/workflows/l2vpn/create_l2vpn.py
+++ b/workflows/l2vpn/create_l2vpn.py
@@ -12,12 +12,13 @@
 # limitations under the License.
 
 
+from pydantic_forms.types import UUIDstr
 import uuid
 from random import randrange
 from typing import TypeAlias, cast
 
 from orchestrator.targets import Target
-from orchestrator.types import SubscriptionLifecycle, UUIDstr
+from orchestrator.types import SubscriptionLifecycle
 from orchestrator.workflow import StepList, begin, step
 from orchestrator.workflows.steps import set_status, store_process_subscription
 from orchestrator.workflows.utils import create_workflow

--- a/workflows/l2vpn/modify_l2vpn.py
+++ b/workflows/l2vpn/modify_l2vpn.py
@@ -12,7 +12,8 @@
 # limitations under the License.
 
 
-from orchestrator.types import SubscriptionLifecycle, UUIDstr
+from pydantic_forms.types import UUIDstr
+from orchestrator.types import SubscriptionLifecycle
 from orchestrator.workflow import StepList, begin, step
 from orchestrator.workflows.steps import set_status
 from orchestrator.workflows.utils import modify_workflow

--- a/workflows/l2vpn/terminate_l2vpn.py
+++ b/workflows/l2vpn/terminate_l2vpn.py
@@ -12,7 +12,8 @@
 # limitations under the License.
 
 
-from orchestrator.types import InputForm, UUIDstr
+from pydantic_forms.types import UUIDstr
+from pydantic_forms.types import InputForm
 from orchestrator.workflow import StepList, begin, step
 from orchestrator.workflows.utils import terminate_workflow
 from pydantic_forms.core import FormPage

--- a/workflows/l2vpn/validate_l2vpn.py
+++ b/workflows/l2vpn/validate_l2vpn.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from orchestrator.types import State
+from pydantic_forms.types import State
 from orchestrator.workflow import StepList, begin, step
 from orchestrator.workflows.utils import validate_workflow
 

--- a/workflows/node/create_node.py
+++ b/workflows/node/create_node.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 
+from pydantic_forms.types import UUIDstr
 import uuid
 import json
 from random import randrange
@@ -19,7 +20,7 @@ from typing import TypeAlias, cast
 
 from orchestrator.services.products import get_product_by_id
 from orchestrator.targets import Target
-from orchestrator.types import SubscriptionLifecycle, UUIDstr
+from orchestrator.types import SubscriptionLifecycle
 from orchestrator.workflow import StepList, begin, step
 from orchestrator.workflows.steps import store_process_subscription
 from orchestrator.workflows.utils import create_workflow
@@ -118,6 +119,7 @@ def reserve_loopback_addresses(subscription: NodeProvisioning) -> State:
     )
     return {"subscription": subscription}
 
+
 @step("Install node config")
 def provision_node(
     subscription: NodeProvisioning,
@@ -137,6 +139,7 @@ def provision_node(
     )
 
     return {"subscription": subscription}
+
 
 @step("Provision node in NRM")
 def provision_node_in_nrm(subscription: NodeProvisioning) -> State:

--- a/workflows/node/modify_node.py
+++ b/workflows/node/modify_node.py
@@ -10,13 +10,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from pydantic_forms.types import UUIDstr
 from typing import TypeAlias, cast
 
 import structlog
 from orchestrator.services.products import get_product_by_id
-from orchestrator.types import SubscriptionLifecycle, UUIDstr
 from orchestrator.workflow import StepList, begin, step
-from orchestrator.workflows.steps import set_status
 from orchestrator.workflows.utils import modify_workflow, ensure_provisioning_status
 from pydantic_forms.core import FormPage
 from pydantic_forms.types import FormGenerator, State

--- a/workflows/node/modify_sync_ports.py
+++ b/workflows/node/modify_sync_ports.py
@@ -12,10 +12,11 @@
 # limitations under the License.
 
 
+from pydantic_forms.types import State
 from typing import List, Tuple
 
 import structlog
-from orchestrator.types import State, SubscriptionLifecycle
+from orchestrator.types import SubscriptionLifecycle
 from orchestrator.workflow import StepList, begin, step
 from orchestrator.workflows.steps import set_status
 from orchestrator.workflows.utils import modify_initial_input_form_generator, modify_workflow

--- a/workflows/node/shared/steps.py
+++ b/workflows/node/shared/steps.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 
-from orchestrator.types import State
+from pydantic_forms.types import State
 from orchestrator.workflow import step
 
 from products.product_types.node import NodeProvisioning

--- a/workflows/node/terminate_node.py
+++ b/workflows/node/terminate_node.py
@@ -12,7 +12,8 @@
 # limitations under the License.
 
 
-from orchestrator.types import InputForm, UUIDstr
+from pydantic_forms.types import UUIDstr
+from pydantic_forms.types import InputForm
 from orchestrator.workflow import StepList, begin, step
 from orchestrator.workflows.utils import terminate_workflow
 from pydantic_forms.core import FormPage

--- a/workflows/node/validate_node.py
+++ b/workflows/node/validate_node.py
@@ -12,8 +12,8 @@
 # limitations under the License.
 
 
+from pydantic_forms.types import State
 from deepdiff import DeepDiff
-from orchestrator.types import State
 from orchestrator.workflow import StepList, begin, step
 from orchestrator.workflows.utils import validate_workflow
 

--- a/workflows/port/create_port.py
+++ b/workflows/port/create_port.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 
+from pydantic_forms.types import UUIDstr
 import uuid
 import json
 from random import randrange
@@ -19,7 +20,7 @@ from typing import TypeAlias, cast
 
 from orchestrator.services.products import get_product_by_id
 from orchestrator.targets import Target
-from orchestrator.types import SubscriptionLifecycle, UUIDstr
+from orchestrator.types import SubscriptionLifecycle
 from orchestrator.workflow import StepList, begin, step
 from orchestrator.workflows.steps import store_process_subscription
 from orchestrator.workflows.utils import create_workflow
@@ -129,6 +130,7 @@ def provision_port_in_nrm(subscription: PortProvisioning) -> State:
     subscription.port.nrm_id = randrange(2**16)
     return {"subscription": subscription}
 
+
 @step("Install port config")
 def provision_port(
     subscription: PortProvisioning,
@@ -148,6 +150,7 @@ def provision_port(
     )
 
     return {"subscription": subscription}
+
 
 @create_workflow("Create port", initial_input_form=initial_input_form_generator)
 def create_port() -> StepList:

--- a/workflows/port/modify_port.py
+++ b/workflows/port/modify_port.py
@@ -12,7 +12,8 @@
 # limitations under the License.
 
 
-from orchestrator.types import SubscriptionLifecycle, UUIDstr
+from pydantic_forms.types import UUIDstr
+from orchestrator.types import SubscriptionLifecycle
 from orchestrator.workflow import StepList, begin, step
 from orchestrator.workflows.steps import set_status
 from orchestrator.workflows.utils import modify_workflow

--- a/workflows/port/shared/steps.py
+++ b/workflows/port/shared/steps.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 
-from orchestrator.types import State
+from pydantic_forms.types import State
 from orchestrator.workflow import step
 
 from products.product_types.port import PortProvisioning

--- a/workflows/port/terminate_port.py
+++ b/workflows/port/terminate_port.py
@@ -12,7 +12,9 @@
 # limitations under the License.
 
 
-from orchestrator.types import InputForm, SubscriptionLifecycle, UUIDstr
+from pydantic_forms.types import UUIDstr
+from pydantic_forms.types import InputForm
+from orchestrator.types import SubscriptionLifecycle
 from orchestrator.workflow import StepList, begin, step
 from orchestrator.workflows.steps import set_status
 from orchestrator.workflows.utils import terminate_workflow

--- a/workflows/port/validate_port.py
+++ b/workflows/port/validate_port.py
@@ -12,8 +12,8 @@
 # limitations under the License.
 
 
+from pydantic_forms.types import State
 from deepdiff import DeepDiff
-from orchestrator.types import State
 from orchestrator.workflow import StepList, begin, step
 from orchestrator.workflows.utils import validate_workflow
 

--- a/workflows/shared.py
+++ b/workflows/shared.py
@@ -10,6 +10,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from pydantic_forms.types import UUIDstr
+from pydantic_forms.types import SummaryData
 from pprint import pformat
 from typing import Annotated, Generator, List, TypeAlias, cast
 
@@ -23,7 +25,7 @@ from orchestrator.db import (
     SubscriptionTable,
 )
 from orchestrator.domain.base import ProductBlockModel
-from orchestrator.types import SubscriptionLifecycle, SummaryData, UUIDstr
+from orchestrator.types import SubscriptionLifecycle
 from pydantic import ConfigDict
 from pydantic_forms.core import FormPage
 from pydantic_forms.validators import Choice, MigrationSummary, migration_summary
@@ -106,9 +108,7 @@ def free_port_selector(node_subscription_id: UUIDstr, speed: int, enum: str = "P
     node = Node.from_subscription(node_subscription_id)
     interfaces = {
         str(interface.id): interface.name
-        for interface in netbox.get_interfaces(
-            device=node.node.node_name, speed=speed * 1000, enabled=False
-        )
+        for interface in netbox.get_interfaces(device=node.node.node_name, speed=speed * 1000, enabled=False)
     }
     return Choice(enum, zip(interfaces.keys(), interfaces.items()))  # type:ignore
 

--- a/workflows/tasks/bootstrap_netbox.py
+++ b/workflows/tasks/bootstrap_netbox.py
@@ -12,10 +12,10 @@
 # limitations under the License.
 
 
+from pydantic_forms.types import State
 import structlog
 from orchestrator import workflow
 from orchestrator.targets import Target
-from orchestrator.types import State
 from orchestrator.workflow import StepList, done, init, step
 
 from services import netbox


### PR DESCRIPTION
For some reason the latest redis (7.4.3) and nginx (1.27.5) images failed to start up for me with the cryptic error `exec /docker-entrypoint.sh: exec format error`. Pinning both images to a slightly older version resolved this. Perhaps a mac specific problem, looking forward to comments whether more people are experiencing this issue without the version pin.

Also fixed some imports that were removed from orchestrator-core 3.x and moved to the pydantic-forms library.