### PR TITLE
Bump core to 4.0.4 and example-orchestrator-ui to 3.4.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,7 +144,7 @@ services:
 
   orchestrator-ui:
     container_name: orchestrator-ui
-    image: "ghcr.io/workfloworchestrator/example-orchestrator-ui:2.14.0"  # TODO make it possible to override the tag
+    image: "ghcr.io/workfloworchestrator/example-orchestrator-ui:3.4.0"  # TODO make it possible to override the tag
     env_file:
       - ./docker/orchestrator-ui/orchestrator-ui.env
       - path: ./docker/overrides/orchestrator-ui/orchestrator-ui.env

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-orchestrator-core==2.8.0
+orchestrator-core==4.0.4
 deepdiff==8.0.1
 rich==13.9.4
 pynetbox==7.4.1

--- a/workflows/port/modify_port.py
+++ b/workflows/port/modify_port.py
@@ -19,7 +19,7 @@ from orchestrator.workflows.steps import set_status
 from orchestrator.workflows.utils import modify_workflow
 from pydantic_forms.core import FormPage
 from pydantic_forms.types import FormGenerator, State
-from pydantic_forms.validators import Label, ReadOnlyField
+from pydantic_forms.validators import Label, read_only_field
 
 from products.product_types.port import Port, PortProvisioning
 from products.services.description import description
@@ -36,10 +36,10 @@ def initial_input_form_generator(subscription_id: UUIDstr) -> FormGenerator:
 
         port_settings: Label
 
-        node_name: ReadOnlyField(port.node.node_name)
-        port_name: ReadOnlyField(port.port_name)
-        port_type: ReadOnlyField(port.port_type)
-        port_mode: ReadOnlyField(port.port_mode)
+        node_name: read_only_field(port.node.node_name)
+        port_name: read_only_field(port.port_name)
+        port_type: read_only_field(port.port_type)
+        port_mode: read_only_field(port.port_mode)
         port_description: str = port.port_description
         auto_negotiation: bool = port.auto_negotiation
         lldp: bool = port.lldp


### PR DESCRIPTION
Bump:
* orchestrator-core from 2.8.0 to 4.0.4
* example-orchestrator-ui from 2.14.0 to 3.4.0