### PR TITLE
Example of reconcile workflow for L2VPN

### DIFF
--- a/migrations/versions/schema/2025-08-28_0e8d17ce0f06_reconcile_workflows_l2vpn.py
+++ b/migrations/versions/schema/2025-08-28_0e8d17ce0f06_reconcile_workflows_l2vpn.py
@@ -1,0 +1,40 @@
+"""Reconcile workflows L2VPN.
+
+Revision ID: 0e8d17ce0f06
+Revises: d946c20663d3
+Create Date: 2025-08-28 13:02:03.796540
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0e8d17ce0f06"
+down_revision = "d946c20663d3"
+branch_labels = None
+depends_on = None
+
+
+from orchestrator.migrations.helpers import create_workflow, delete_workflow
+
+new_workflows = [
+    {
+        "name": "reconcile_l2vpn",
+        "target": "RECONCILE",
+        "description": "Reconcile SN8 L2Vpn",
+        "product_type": "L2vpn",
+    }
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for workflow in new_workflows:
+        create_workflow(conn, workflow)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    for workflow in new_workflows:
+        delete_workflow(conn, workflow["name"])

--- a/workflows/__init__.py
+++ b/workflows/__init__.py
@@ -37,6 +37,8 @@ LazyWorkflowInstance("workflows.l2vpn.create_l2vpn", "create_l2vpn")
 LazyWorkflowInstance("workflows.l2vpn.modify_l2vpn", "modify_l2vpn")
 LazyWorkflowInstance("workflows.l2vpn.terminate_l2vpn", "terminate_l2vpn")
 LazyWorkflowInstance("workflows.l2vpn.validate_l2vpn", "validate_l2vpn")
+LazyWorkflowInstance("workflows.l2vpn.modify_l2vpn", "reconcile_l2vpn")
+
 
 LazyWorkflowInstance("workflows.tasks.bootstrap_netbox", "task_bootstrap_netbox")
 LazyWorkflowInstance("workflows.tasks.wipe_netbox", "task_wipe_netbox")

--- a/workflows/l2vpn/modify_l2vpn.py
+++ b/workflows/l2vpn/modify_l2vpn.py
@@ -67,6 +67,7 @@ def update_l2vpn_in_nrm(subscription: L2vpnProvisioning) -> State:
     return {"subscription": subscription}
 
 
+# variable containing update steps which are both used in modify and reconcile workflows
 update_l2vpn_in_external_systems = begin >> update_l2vpn_in_nrm
 
 
@@ -82,6 +83,6 @@ def modify_l2vpn() -> StepList:
     )
 
 
-@reconcile_workflow("Reconcile SN8 L2Vpn")
+@reconcile_workflow("Reconcile l2vpn")
 def reconcile_l2vpn() -> StepList:
     return begin >> update_l2vpn_in_external_systems


### PR DESCRIPTION

This pull request introduces support an example for using a reconcile workflow for L2VPN subscription. The reconcile workflow enables synchronization of existing subscription configurations with external systems (OSS/BSS) without requiring user input.

**Reconcile workflow support and refactoring:**

* Added a new `@reconcile_workflow` decorator and defined the `reconcile_l2vpn` workflow in `workflows/l2vpn/modify_l2vpn.py`, sharing update steps with the existing `modify_l2vpn` workflow via the new `update_l2vpn_in_external_systems` variable.
* Updated the workflow initialization in `workflows/__init__.py` to include the `reconcile_l2vpn` workflow.
* Added a migration script `migrations/versions/schema/2025-08-28_0e8d17ce0f06_reconcile_workflows_l2vpn.py` to register the new `reconcile_l2vpn` workflow in the database.
* Expanded the `README.md` with a new section explaining reconcile workflows, their usage, and code examples.

[Issue](https://github.com/orgs/workfloworchestrator/projects/7?pane=issue&itemId=123786992&issue=workfloworchestrator%7Corchestrator-core%7C1026)
[Dependency on orchestrator-core PR](https://github.com/workfloworchestrator/orchestrator-core/pull/1048)