### PR TITLE
Bumping versions of key elements like NetBox and LSO to new iterations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ export PYTHONUNBUFFERED=1
 export OAUTH2_ACTIVE=0
 export LOG_LEVEL=DEBUG
 export WEBSOCKET_BROADCASTER_URL="redis://localhost:6379"
+# export COMPOSE_PROFILES=lso # unhash the start of this line to also start up lso container

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ x-netbox: &netbox
 services:
   postgres:
     container_name: postgres
-    image: "postgres:14"
+    image: "postgres:17-alpine"
     ports:
       - "5432:5432"
     environment:
@@ -53,7 +53,7 @@ services:
 
   redis:
     container_name: redis
-    image: docker.io/redis:7.4.2-alpine
+    image: docker.io/redis:8-alpine
     command:
       - sh
       - -c # this is to evaluate the $REDIS_PASSWORD from the env
@@ -90,7 +90,7 @@ services:
 
   federation:
     container_name: federation
-    image: ghcr.io/apollographql/router:v1.47.0
+    image: ghcr.io/apollographql/router:v2.6.2
     ports:
       - "4000:4000"
     depends_on:
@@ -200,7 +200,7 @@ services:
 
   lso:
     container_name: orchestrator-lso
-    image: orchestrator-lso
+    #image: orchestrator-lso
     profiles:
       - lso
     build:
@@ -215,6 +215,7 @@ services:
     volumes:
       - ./ansible/plays_and_roles:/app/wfo/ansible
       - ./ansible/inventory:/opt/ansible_inventory
+      - ./docker/lso/config.json:/app/config.json
 
   nginx:
     container_name: nginx

--- a/docker/federation/rover.Dockerfile
+++ b/docker/federation/rover.Dockerfile
@@ -5,7 +5,7 @@ RUN apt update && apt install curl -y
 RUN useradd --create-home --shell /bin/bash rover-user
 
 USER rover-user
-RUN curl -sSL https://rover.apollo.dev/nix/v0.23.0 | sh
+RUN curl -sSL https://rover.apollo.dev/nix/v0.35.0 | sh
 
 USER root
 RUN apt remove curl -y

--- a/docker/federation/supergraph-config.yaml
+++ b/docker/federation/supergraph-config.yaml
@@ -1,4 +1,4 @@
-federation_version: =2.7.1
+federation_version: =2.9.3
 subgraphs:
   orchestrator:
     routing_url: http://orchestrator:8080/api/graphql

--- a/docker/lso/Dockerfile
+++ b/docker/lso/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 RUN apk add --update --no-cache gcc libc-dev libffi-dev
 
-RUN pip install orchestrator-lso=="2.0.1"
+RUN pip install orchestrator-lso=="2.2.0"
 
 RUN pip install pynetbox
 

--- a/docker/lso/config.json
+++ b/docker/lso/config.json
@@ -1,0 +1,3 @@
+{
+  "ansible_playbooks_root_dir": "/app/ansible"
+}

--- a/docker/netbox/Dockerfile
+++ b/docker/netbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM netboxcommunity/netbox:v4.0-2.9.1
+FROM netboxcommunity/netbox:v4.4.1
 
 
 # Patch strawberry schema to enable federation


### PR DESCRIPTION
The purpose of this pull request is to contribute an upstream update as a potential candidate to update the versions of things like NetBox and LSO within the example-orchestrator stack.

My rationale for proposing these changes are to allow for the opportunity to be presented to users wishing to test Workflow Orchestrator with a new version of NetBox - specifically a version beyond 4.2.0 where the [Virtual Circuits table was introduced](https://github.com/netbox-community/netbox/issues/13086). This is a key milestone for NetBox and it allows operators to start to use NetBox as a more robust Service Inventory Management tool (as we have done in HEAnet).

**Please note: this Pull Request is not 100% complete at this point and I may need assistance in resolving the issues with GraphQL federation**