### PR TITLE
remove netbox-housekeeping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,20 +147,6 @@ services:
       interval: 15s
       test: "ps -aux | grep -v grep | grep -q rqworker || exit 1"
 
-  netbox-housekeeping:
-    <<: *netbox
-    container_name: netbox-housekeeping
-    depends_on:
-      netbox:
-        condition: service_healthy
-    command:
-      - /opt/netbox/housekeeping.sh
-    healthcheck:
-      start_period: 20s
-      timeout: 3s
-      interval: 15s
-      test: "ps -aux | grep -v grep | grep -q housekeeping || exit 1"
-
   orchestrator-ui:
     container_name: orchestrator-ui
     image: ${ORCH_UI_TAG:-ghcr.io/workfloworchestrator/example-orchestrator-ui:latest}


### PR DESCRIPTION
The housekeeping script is gone starting on NetBox version 4.4.0.

https://netboxlabs.com/docs/netbox/release-notes/version-4.4#v440-2025-09-02