### PR TITLE
entrypoint.sh: do not pull Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "example-orchestrator"
 version = "0.1.0"
-requires-python = ">=3.12"
+requires-python = ">=3.12, <=3.13"
 dependencies = [
   "deepdiff==8.6.1",
   "orchestrator-core==4.0.4",


### PR DESCRIPTION
The `uv sync` command in `docker/orchestrator/entrypoint.sh` will pull Python 3.14 and then attempt to build dependencies.

I tried for a while to deploy the orchestrator, adding `build-essential`, `postgresql-client-17`, `libpq-dev` and `rust-all` to the final stage of the orchestrator-core image (`orchestrator-core/Dockerfile` line 16), until it failed to build `pyo3-ffi`, which apparently is one of Pydantic's dependencies.

Then I tried a change to the Python version in the toml file.