### PR TITLE
Add github workflow to validate docker compose

### DIFF
--- a/.github/workflows/docker-compose-test.yml
+++ b/.github/workflows/docker-compose-test.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Start Docker Compose stack
         run: |
           docker compose up -d --build
-          docker compose ps
 
       - name: Wait for services with health checks to become healthy
         run: |
@@ -36,6 +35,43 @@ jobs:
               sleep 5
             done
           '
+
+      - name: Check that services are running.
+        run: |
+          errors=0
+          docker compose ps --all --format "{{.Name}} {{.Service}} {{.State}}" | while read -r line; do
+            name=$(echo "$line" | awk '{print $1}')
+            service=$(echo "$line" | awk '{print $2}')
+            state=$(echo "$line" | awk '{print $3}')
+            health=$(echo "$line" | awk '{print $4}')
+
+            if [ "$state" = "running" ]; then
+              if [ "$health" = "unhealthy" ]; then
+                echo "❌ $service ($name) is running but unhealthy: $health"
+                errors=$((errors+1))
+              elif [ "$health" = "healthy" ]; then
+                echo "🟢 $service ($name) is running, health: $health"
+              else
+                echo "🟢 $service ($name) is running, health: no health check"
+              fi
+            elif [ "$state" = "exited" ]; then
+              echo "⚪ $service ($name) has exited normally (exit 0)"
+            else
+              echo "❌ $service ($name) failed or exited unexpectedly: state=$state, health=$health"
+              docker compose ps --all
+              errors=$((errors+1))
+            fi
+          done
+
+          if [ "$errors" -gt 0 ]; then
+            echo "❌ $errors service(s) failed or unhealthy"
+            exit 1
+          else
+            echo "✅ All services are running or exited normally"
+          fi
+
+      - name: Check errors inside service logs
+        run: docker compose logs --no-color | grep -v "uvicorn\.error" | grep -i "error" && exit 1 || echo "No errors detected."
 
       - name: Tear down Docker Compose
         if: always()


### PR DESCRIPTION
adds a github workflow that starts the docker compose and then:
1. waits for services to be healthy for 180 seconds
2. checks if all services are running correctly or if they exited correctly (for rover-compose)
3. checks the logs inside the services if they contain any errors.

closes: https://github.com/workfloworchestrator/example-orchestrator/issues/51

tested with removing the federation fix, which breaks rover: [workflow action](https://github.com/workfloworchestrator/example-orchestrator/actions/runs/18910643232/job/53980141350)
tested with an error log in orchestrator : [workflow action](https://github.com/workfloworchestrator/example-orchestrator/actions/runs/18910788851/job/53980666261)