### PR TITLE
Improve exited service check to check it exited with 0

### DIFF
--- a/.github/workflows/docker-compose-test.yml
+++ b/.github/workflows/docker-compose-test.yml
@@ -3,7 +3,7 @@ name: Docker Compose Validation
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [main, master]
 
 jobs:
   validate-compose:

--- a/.github/workflows/docker-compose-test.yml
+++ b/.github/workflows/docker-compose-test.yml
@@ -58,7 +58,6 @@ jobs:
               echo "⚪ $service ($name) has exited normally (exit 0)"
             else
               echo "❌ $service ($name) failed or exited unexpectedly: state=$state, health=$health"
-              docker compose ps --all
               errors=$((errors+1))
             fi
           done

--- a/.github/workflows/docker-compose-test.yml
+++ b/.github/workflows/docker-compose-test.yml
@@ -54,7 +54,7 @@ jobs:
               else
                 echo "🟢 $service ($name) is running, health: no health check"
               fi
-            elif [ "$state" = "exited" ]; then
+            elif [ "$state" = "exited (0)" ]; then
               echo "⚪ $service ($name) has exited normally (exit 0)"
             else
               echo "❌ $service ($name) failed or exited unexpectedly: state=$state, health=$health"


### PR DESCRIPTION
exiting with 1 errors the pipeline directly on `docker compose up`: [orchestrator exit 1 pipeline](https://github.com/workfloworchestrator/example-orchestrator/actions/runs/18945027908/job/54093816984)
This is still useful to check if nothing exited with 1 after health checks complete.

- include master as branch to run this pipeline on.

related: https://github.com/workfloworchestrator/example-orchestrator/issues/51