### PR TITLE
Change task code to use @task decorator

### DIFF
--- a/workflows/tasks/bootstrap_netbox.py
+++ b/workflows/tasks/bootstrap_netbox.py
@@ -13,9 +13,8 @@
 
 
 import structlog
-from orchestrator.core import workflow
-from orchestrator.core.targets import Target
 from orchestrator.core.workflow import StepList, done, init, step
+from orchestrator.core.workflows.utils import task
 
 from pydantic_forms.types import State
 from services import netbox
@@ -81,6 +80,6 @@ def create_prefixes() -> State:
     return {"prefixes_created": prefixes_created}
 
 
-@workflow(target=Target.SYSTEM)
+@task()
 def task_bootstrap_netbox() -> StepList:
     return init >> create_initial_set_of_objects >> create_prefixes >> done

--- a/workflows/tasks/showcase.py
+++ b/workflows/tasks/showcase.py
@@ -1,13 +1,12 @@
 from typing import Annotated, Any, TypeAlias, cast
 
 from annotated_types import Ge, Le
-from orchestrator.core import workflow
 from orchestrator.core.config.assignee import Assignee
 from orchestrator.core.forms import FormPage
 from orchestrator.core.forms.validators import Divider, Label
-from orchestrator.core.targets import Target
 from orchestrator.core.utils.errors import ProcessFailureError
 from orchestrator.core.workflow import StepList, callback_step, conditional, done, init, inputstep, step
+from orchestrator.core.workflows.utils import task
 from pydantic import AfterValidator, ConfigDict, model_validator
 
 from pydantic_forms.types import FormGenerator, State
@@ -173,7 +172,7 @@ suspend_when_requested = conditional(lambda state: state.get("show_suspended_ste
 callback_when_requested = conditional(lambda state: state.get("wait_for_callback") is True)
 
 
-@workflow(initial_input_form=initial_input_form_generator, target=Target.SYSTEM)
+@task(initial_input_form=initial_input_form_generator)
 def task_showcase() -> StepList:
     return (
         init

--- a/workflows/tasks/wipe_netbox.py
+++ b/workflows/tasks/wipe_netbox.py
@@ -13,10 +13,9 @@
 from typing import Annotated
 
 import structlog
-from orchestrator.core import workflow
 from orchestrator.core.forms import FormPage
-from orchestrator.core.targets import Target
 from orchestrator.core.workflow import StepList, done, init, step
+from orchestrator.core.workflows.utils import task
 from pydantic import AfterValidator, ConfigDict
 
 from pydantic_forms.types import FormGenerator, State
@@ -72,6 +71,6 @@ def wipe_all_objects() -> State:
     return {"objects_deleted": objects_deleted}
 
 
-@workflow(initial_input_form=initial_input_form_generator, target=Target.SYSTEM)
+@task(initial_input_form=initial_input_form_generator)
 def task_wipe_netbox() -> StepList:
     return init >> wipe_all_objects >> done


### PR DESCRIPTION
Very small change. Ran e2e tests as well as manually ran the Tasks from the UI locally to verify everything is still working.

```text
v3.13.14 (example-orchestrator) ❯ uv run pytest tests
============================================================================================== test session starts ==============================================================================================
platform darwin -- Python 3.13.14, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/awray2/surf/example-orchestrator
configfile: pyproject.toml
plugins: anyio-4.10.0, base-url-2.1.0, playwright-0.8.0
collected 6 items

tests/e2e/test_showcase.py ......                                                                                                                                                                         [100%]

============================================================================================== 6 passed in 10.12s ===============================================================================================
```
Closes #84 