### PR TITLE
Default bind to 127.0.0.1 and add bind address overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Example workflow orchestrator implementation based on the
     - [Local table](#local-table)
     - [Remote](#remote)
   - [Configuration](#configuration)
+    - [Service bind addresses](#service-bind-addresses)
   - [Docker runtimes](#docker-runtimes)
     - [Apple Silicon (colima + virtiofs)](#apple-silicon-colima--virtiofs)
     - [Fedora / RHEL with Podman](#fedora--rhel-with-podman)
@@ -124,6 +125,16 @@ To access `federation`, point your browser to:
 ```
 http://localhost:4000
 ```
+
+> [!WARNING]
+> This setup is not meant to be used in production!
+> All services bind to `127.0.0.1`, so they are only reachable from the machine
+> running them. This is on purpose: several of them use well-known credentials
+> or no authentication at all. If you run the stack on a remote machine and
+> browse to it from another one, bind the services you need to `0.0.0.0`, for
+> example `BIND_ADDRESS_ORCHESTRATOR_UI=0.0.0.0 docker compose up`. See
+> [Service bind addresses](#service-bind-addresses) for the full list and for
+> the extra steps the UI needs.
 
 ### Using the example orchestrator
 
@@ -1690,6 +1701,58 @@ This approach keeps the orchestrator's customer data in sync with the authoritat
 ## Configuration
 
 Environment variables and orchestrator-core can be overridden for development purposes. Please refer to [this documentation](./docker/overrides/configuration.md) for more details.
+
+### Service bind addresses
+
+Every published port binds to `127.0.0.1` by default, so the services are only
+reachable from the machine running them. This is deliberate as several services either
+use static credentials or no authentication at all, and some services expose a debugger. 
+In short, none of them services should be accessible on a shared network by accident,
+which is what the default configuration ensures.
+
+Each service has its own variable, named `BIND_ADDRESS_<SERVICE>`, that can be
+used for granular overrides of the bind address.
+
+| Variable | Service | Host port(s) |
+| --- | --- | --- |
+| `BIND_ADDRESS_ORCHESTRATOR_UI` | `orchestrator-ui` | 3000 |
+| `BIND_ADDRESS_ORCHESTRATOR` | `orchestrator` | 8080 |
+| `BIND_ADDRESS_ORCHESTRATOR_DEBUGPY` | `orchestrator` | 5678 (debugger) |
+| `BIND_ADDRESS_NETBOX` | `netbox` | 8000 |
+| `BIND_ADDRESS_FEDERATION` | `federation` | 4000 |
+| `BIND_ADDRESS_POSTGRES` | `postgres` | 5432 |
+| `BIND_ADDRESS_LSO` | `lso` | 8001 |
+| `BIND_ADDRESS_EMBEDDINGS` | `embeddings` | 8081 |
+
+To make a service reachable from other machines, bind it to `0.0.0.0` or to one specific host address:
+
+```bash
+BIND_ADDRESS_ORCHESTRATOR_UI=0.0.0.0 docker compose up
+```
+
+This can be made semi-persistent by adding it to the `.env` file.
+
+> [!WARNING]
+> Do not use this for permanent deployments in shared networks. If you do, consult the
+> documentation for each individual component on how to setup authentication.
+
+
+> [!NOTE]
+> The `orchestrator-ui` calls the orchestrator from the *browser*, so exposing
+> the UI on its own is not enough to use it from another machine. Also set
+> `BIND_ADDRESS_ORCHESTRATOR=0.0.0.0` and point the UI at an address the
+> browser can resolve, by overriding `ORCHESTRATOR_API_HOST`,
+> `ORCHESTRATOR_GRAPHQL_HOST` and `ORCHESTRATOR_WEBSOCKET_URL` in
+> `docker/overrides/orchestrator-ui/orchestrator-ui.env`.
+>
+> Similarly, `netbox` rejects form submissions from origins it does not know.
+> When reaching it by hostname or IP instead of `localhost`, add that origin to
+> `CSRF_TRUSTED_ORIGINS` in `docker/overrides/netbox/netbox.env`.
+
+> [!WARNING]
+> `BIND_ADDRESS_ORCHESTRATOR_DEBUGPY` exposes the Python debugger, which has no
+> authentication and allows arbitrary code execution. Only widen it on a network
+> you trust.
 
 ## Docker runtimes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,12 +23,25 @@ x-netbox: &netbox
     - netbox-media-files:/opt/netbox/netbox/media:z
     - ./docker/netbox/data.json:/etc/netbox/data.json
 
+# Published ports bind to the host loopback (127.0.0.1) by default, so the
+# services are only reachable from this machine. Several of them ship without
+# authentication or with well-known credentials, and on Linux published ports
+# bypass the host firewall, so widen these deliberately.
+#
+# Every service has its own BIND_ADDRESS_<SERVICE> variable, named after the
+# compose service in uppercase with dashes replaced by underscores; the
+# orchestrator's debugger has a separate one. To reach a service from another
+# machine, point it at another address:
+#
+#   BIND_ADDRESS_ORCHESTRATOR_UI=0.0.0.0 docker compose up
+#
+# See the "Service bind addresses" section in README.md for details.
 services:
   postgres:
     container_name: postgres
     image: "pgvector/pgvector:pg17"
     ports:
-      - "5432:5432"
+      - "${BIND_ADDRESS_POSTGRES:-127.0.0.1}:5432:5432"
     environment:
       POSTGRES_USER: nwa
       POSTGRES_PASSWORD: nwa
@@ -83,7 +96,7 @@ services:
       - path: ./docker/overrides/embeddings/embeddings.env
         required: false
     ports:
-      - "8081:80"
+      - "${BIND_ADDRESS_EMBEDDINGS:-127.0.0.1}:8081:80"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:80/health"]
       interval: 10s
@@ -112,7 +125,7 @@ services:
     container_name: federation
     image: ghcr.io/apollographql/router:v2.11.0
     ports:
-      - "4000:4000"
+      - "${BIND_ADDRESS_FEDERATION:-127.0.0.1}:4000:4000"
     depends_on:
       rover-compose:
         condition: service_completed_successfully
@@ -128,7 +141,7 @@ services:
     expose:
       - "8080"
     ports:
-      - "8000:8080"
+      - "${BIND_ADDRESS_NETBOX:-127.0.0.1}:8000:8080"
     entrypoint:
       ["/opt/netbox/docker-entrypoint.sh", "/etc/netbox/entrypoint.sh"]
 
@@ -156,7 +169,7 @@ services:
       - path: ./docker/overrides/orchestrator-ui/orchestrator-ui.env
         required: false
     ports:
-      - "3000:3000"
+      - "${BIND_ADDRESS_ORCHESTRATOR_UI:-127.0.0.1}:3000:3000"
     depends_on:
       orchestrator:
         condition: service_started
@@ -171,8 +184,8 @@ services:
     environment:
       LSO_ENABLED: ${LSO_ENABLED:-False}
     ports:
-      - "8080:8080"
-      - "5678:5678" #Enable Python debugger
+      - "${BIND_ADDRESS_ORCHESTRATOR:-127.0.0.1}:8080:8080"
+      - "${BIND_ADDRESS_ORCHESTRATOR_DEBUGPY:-127.0.0.1}:5678:5678" #Enable Python debugger
     expose:
       - 5678 #Enable Python debugger
     volumes:
@@ -221,7 +234,7 @@ services:
       - path: ./docker/overrides/lso/lso.env
         required: false
     ports:
-      - "8001:8000"
+      - "${BIND_ADDRESS_LSO:-127.0.0.1}:8001:8000"
     volumes:
       - ./ansible/plays_and_roles:/app/demo/ansible/playbooks
       - ./ansible/inventory:/opt/ansible_inventory


### PR DESCRIPTION
- Ensure that all docker compose services bind to 127.0.0.1 by default
- Add `BIND_ADDRESS_<SERVICE>` env variable to individually override the bind address per service
- Describe the default settings in the README.md along with an explanation on how to override it (including a warning)